### PR TITLE
Setup authentication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,12 @@ repos:
     rev: "2.1.2"
     hooks:
       - id: prettier
-# - repo: local
-#   hooks:
-#     - id: pytest
-#       name: pytest
-#       entry: ienv\\Scripts\\pytest.exe
-#       language: script
-#       types: [python]
-#       args:
-#         - "-vv"
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: ienv\\Scripts\\pytest.exe
+        language: script
+        types: [python]
+        args:
+          - "-vv"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,3 @@ repos:
     rev: "2.1.2"
     hooks:
       - id: prettier
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: ienv\\Scripts\\pytest.exe
-        language: script
-        types: [python]
-        args:
-          - "-vv"

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
         "level": "DEBUG",
         "formatter": "simple",
         "filename": "server.log",
-        "mode": "w"
+        "mode": "a"
       }
     },
     "loggers": {

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -195,7 +195,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 MEDIA_URL = "/media/"
 
-# LOGIN_REDIRECT_URL = "dashboard"
+LOGIN_REDIRECT_URL = "invoicing:home"
 
 # LOGOUT_REDIRECT_URL = "dashboard"
 

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -202,7 +202,7 @@ MEDIA_URL = "/media/"
 
 LOGIN_REDIRECT_URL = "invoicing:home"
 
-# LOGOUT_REDIRECT_URL = "dashboard"
+LOGOUT_REDIRECT_URL = "invoicing:home"
 
 # Keep this at the end
 

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -91,6 +91,7 @@ else:
 # Application definition
 
 INSTALLED_APPS = [
+    "users",
     "django_invoicing",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -85,7 +85,7 @@ elif DJANGO_ENVIRONMENT == "DEVELOPMENT":
         os.path.join(BASE_DIR, "django_apps\\static\\django_apps"),
         # os.path.join(BASE_DIR, "django_invoicing\\static\\django_invoicing"),
     ]
-    ALLOWED_HOSTS = []
+    ALLOWED_HOSTS = ["*"]
 else:
     pass
 

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -156,18 +156,18 @@ DATABASES = {
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
-    },
+    # {
+    #     "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    # },
+    # {
+    #     "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    # },
+    # {
+    #     "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    # },
+    # {
+    #     "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    # },
 ]
 
 

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -56,6 +56,13 @@ try:
     DBHOST = os.environ["DBHOST"]
     DBPORT = os.environ["DBPORT"]
     DBTEST = os.environ["DBTEST"]
+    EMAIL_HOST = os.environ["EMAIL_HOST"]
+    EMAIL_PORT = os.environ["EMAIL_PORT"]
+    EMAIL_HOST_USER = os.environ["EMAIL_HOST_USER"]
+    EMAIL_HOST_PASSWORD = os.environ["EMAIL_HOST_PASSWORD"]
+    EMAIL_USE_TLS = os.environ["EMAIL_USE_TLS"]
+    DEFAULT_FROM_EMAIL = os.environ["DEFAULT_FROM_EMAIL"]
+    EMAIL_BACKEND = os.environ["EMAIL_BACKEND"]
 
 except KeyError:
     path_env = os.path.join(BASE_DIR.parent, ".env")
@@ -68,6 +75,13 @@ except KeyError:
     DBHOST = os.environ["DBHOST"]
     DBPORT = os.environ["DBPORT"]
     DBTEST = os.environ["DBTEST"]
+    EMAIL_HOST = os.environ["EMAIL_HOST"]
+    EMAIL_PORT = os.environ["EMAIL_PORT"]
+    EMAIL_HOST_USER = os.environ["EMAIL_HOST_USER"]
+    EMAIL_HOST_PASSWORD = os.environ["EMAIL_HOST_PASSWORD"]
+    EMAIL_USE_TLS = os.environ["EMAIL_USE_TLS"]
+    DEFAULT_FROM_EMAIL = os.environ["DEFAULT_FROM_EMAIL"]
+    EMAIL_BACKEND = os.environ["EMAIL_BACKEND"]
 
 if DJANGO_ENVIRONMENT == "PRODUCTION":
     ALLOWED_HOSTS = [
@@ -89,6 +103,10 @@ elif DJANGO_ENVIRONMENT == "DEVELOPMENT":
 else:
     pass
 
+if EMAIL_USE_TLS == "True":
+    EMAIL_USE_TLS = True
+if EMAIL_USE_TLS == "False":
+    EMAIL_USE_TLS = False
 
 # Application definition
 

--- a/django_invoicing/django_apps/settings.py
+++ b/django_invoicing/django_apps/settings.py
@@ -55,6 +55,7 @@ try:
     DBPASSWORD = os.environ["DBPASSWORD"]
     DBHOST = os.environ["DBHOST"]
     DBPORT = os.environ["DBPORT"]
+    DBTEST = os.environ["DBTEST"]
 
 except KeyError:
     path_env = os.path.join(BASE_DIR.parent, ".env")
@@ -66,6 +67,7 @@ except KeyError:
     DBPASSWORD = os.environ["DBPASSWORD"]
     DBHOST = os.environ["DBHOST"]
     DBPORT = os.environ["DBPORT"]
+    DBTEST = os.environ["DBTEST"]
 
 if DJANGO_ENVIRONMENT == "PRODUCTION":
     ALLOWED_HOSTS = [
@@ -149,6 +151,9 @@ DATABASES = {
         "PASSWORD": DBPASSWORD,
         "HOST": DBHOST,
         "PORT": DBPORT,
+        "TEST": {
+            "NAME": DBTEST,
+        },
     }
 }
 

--- a/django_invoicing/django_apps/urls.py
+++ b/django_invoicing/django_apps/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path(
         "invoicing/", include("django_invoicing.urls", namespace="invoicing")
     ),
+    path("users/", include("users.urls")),
 ]

--- a/django_invoicing/django_invoicing/templates/homepage.html
+++ b/django_invoicing/django_invoicing/templates/homepage.html
@@ -54,7 +54,11 @@
         </ul>
       </vstack>
       <spacer></spacer>
+      {% if user.is_authenticated %}
       <vstack spacing="l">
+        <vstack spacing="s" stretch="" align-x="center" align-y="center">
+          <h2>Your Dashboard</h2>
+        </vstack>
         <vstack spacing="xs">
           <aside class="pa-l">
             <vstack>
@@ -201,6 +205,7 @@
         </vstack>
       </vstack>
       <spacer></spacer>
+      {% endif %}
       <vstack spacing="l">
         <vstack spacing="xs">
           <aside class="pa-s">

--- a/django_invoicing/django_invoicing/templates/homepage.html
+++ b/django_invoicing/django_invoicing/templates/homepage.html
@@ -29,6 +29,9 @@
         <span
           >{% if user.is_authenticated %}
           <a href="{% url 'logout' %}"><button>Logout</button></a>
+          <a href="{% url 'password_change' %}"
+            ><button>Change Password</button></a
+          >
           {% else %}
           <a href="{% url 'login' %}"><button>Login</button></a>
 

--- a/django_invoicing/django_invoicing/templates/homepage.html
+++ b/django_invoicing/django_invoicing/templates/homepage.html
@@ -26,6 +26,14 @@
       </vstack>
       <hstack spacing="s" stretch="" align-x="center" align-y="center">
         <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+        <span
+          >{% if user.is_authenticated %}
+          <a href="{% url 'logout' %}"><button>Logout</button></a>
+          {% else %}
+          <a href="{% url 'login' %}"><button>Login</button></a>
+
+          {% endif %}</span
+        >
       </hstack>
       <spacer></spacer>
       <vstack spacing="s" stretch="" align-x="center" align-y="center">

--- a/django_invoicing/django_invoicing/templates/homepage.html
+++ b/django_invoicing/django_invoicing/templates/homepage.html
@@ -24,6 +24,9 @@
           >
         </p>
       </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+      </hstack>
       <spacer></spacer>
       <vstack spacing="s" stretch="" align-x="center" align-y="center">
         <h3>

--- a/django_invoicing/users/admin.py
+++ b/django_invoicing/users/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/django_invoicing/users/apps.py
+++ b/django_invoicing/users/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    name = "users"

--- a/django_invoicing/users/forms.py
+++ b/django_invoicing/users/forms.py
@@ -1,0 +1,6 @@
+from django.contrib.auth.forms import UserCreationForm
+
+
+class NewUserCreationForm(UserCreationForm):
+    class Meta(UserCreationForm.Meta):
+        fields = UserCreationForm.Meta.fields + ("email",)

--- a/django_invoicing/users/models.py
+++ b/django_invoicing/users/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/django_invoicing/users/templates/register.html
+++ b/django_invoicing/users/templates/register.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+      </hstack>
+      <spacer></spacer>
+      {% if user.is_authenticated %}
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack spacing="s" stretch="" align-x="center" align-y="center">
+              <h2>You are already logged in!</h2>
+              <i><a href="{% url 'invoicing:home' %}">Back to home</a></i>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+      {% else %}
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack>
+              <form method="POST">
+                {% csrf_token %} {{form.as_p}}
+                <button type="submit" value="register">REGISTER</button>
+              </form>
+              <span
+                ><a href="{% url 'login' %}"><button>Login</button></a></span
+              >
+              <a href="{% url 'invoicing:home' %}">Back to home</a>
+              <a href="{% url 'password_reset' %}">Reset your password</a>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+      {% endif %}
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/login.html
+++ b/django_invoicing/users/templates/registration/login.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+      </hstack>
+      <spacer></spacer>
+      {% if user.is_authenticated %}
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack spacing="s" stretch="" align-x="center" align-y="center">
+              <h2>You are already logged in!</h2>
+              <i><a href="{% url 'invoicing:home' %}">Back to home</a></i>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+      {% else %}
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack>
+              <form method="POST">
+                {% csrf_token %} {{form.as_p}}
+                <button type="submit" value="login">LOGIN</button>
+              </form>
+              <a href="{% url 'invoicing:home' %}">Back to home</a>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+      {% endif %}
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/login.html
+++ b/django_invoicing/users/templates/registration/login.html
@@ -46,6 +46,7 @@
                 <button type="submit" value="login">LOGIN</button>
               </form>
               <a href="{% url 'invoicing:home' %}">Back to home</a>
+              <a href="{% url 'password_reset' %}">Reset your password</a>
             </vstack>
           </aside>
         </vstack>

--- a/django_invoicing/users/templates/registration/login.html
+++ b/django_invoicing/users/templates/registration/login.html
@@ -45,6 +45,7 @@
                 {% csrf_token %} {{form.as_p}}
                 <button type="submit" value="login">LOGIN</button>
               </form>
+              <a href="{% url 'register' %}">Register your account</a>
               <a href="{% url 'invoicing:home' %}">Back to home</a>
               <a href="{% url 'password_reset' %}">Reset your password</a>
             </vstack>

--- a/django_invoicing/users/templates/registration/password_change_done.html
+++ b/django_invoicing/users/templates/registration/password_change_done.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+        <h2>Password has been successfully changed</h2>
+      </hstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <a href="{% url 'invoicing:home' %}"><button>Home</button></a>
+      </hstack>
+
+      <spacer></spacer>
+
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/password_change_form.html
+++ b/django_invoicing/users/templates/registration/password_change_form.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+        <h2>Change your password</h2>
+      </hstack>
+      <spacer></spacer>
+
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack>
+              <form method="POST">
+                {% csrf_token %} {{form.as_p}}
+                <button type="submit" value="login">LOGIN</button>
+              </form>
+              <a href="{% url 'invoicing:home' %}">Back to home</a>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/password_change_form.html
+++ b/django_invoicing/users/templates/registration/password_change_form.html
@@ -33,7 +33,7 @@
             <vstack>
               <form method="POST">
                 {% csrf_token %} {{form.as_p}}
-                <button type="submit" value="login">LOGIN</button>
+                <button type="submit" value="login">Change Passowrd</button>
               </form>
               <a href="{% url 'invoicing:home' %}">Back to home</a>
             </vstack>

--- a/django_invoicing/users/templates/registration/password_reset_complete.html
+++ b/django_invoicing/users/templates/registration/password_reset_complete.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Password has been successfully changed</h2>
+      </hstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <a href="{% url 'invoicing:home' %}"><button>Home</button></a>
+      </hstack>
+
+      <spacer></spacer>
+
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/password_reset_confirm.html
+++ b/django_invoicing/users/templates/registration/password_reset_confirm.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Change your password</h2>
+      </hstack>
+      <spacer></spacer>
+
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack>
+              <form method="POST">
+                {% csrf_token %} {{form.as_p}}
+                <button type="submit" value="login">Change Passowrd</button>
+              </form>
+              <a href="{% url 'invoicing:home' %}">Back to home</a>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/password_reset_done.html
+++ b/django_invoicing/users/templates/registration/password_reset_done.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Hello {{ user.username | default:"Guest" }}!</h2>
+        <h2>Password reset email has been sent!</h2>
+      </hstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <a href="{% url 'invoicing:home' %}"><button>Home</button></a>
+      </hstack>
+
+      <spacer></spacer>
+
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/templates/registration/password_reset_form.html
+++ b/django_invoicing/users/templates/registration/password_reset_form.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %} {% load static %} {% block header_content %}
+{{block.super }}
+<body>
+  <main>
+    <vstack spacing="m">
+      <vstack spacing="s" stretch="" align-x="center" align-y="center">
+        <hstack responsive="" spacing="xl">
+          <img
+            src="{% static 'img/logo.png' %}"
+            alt="logo"
+            height="150"
+            width="150"
+          />
+          <h1>Welcome to Invoicing!</h1>
+        </hstack>
+        <p><i>Your personal Invoicing app!</i></p>
+        <p>
+          Created by
+          <a href="https://d-bhatta.github.io/Portfolio-Main/"
+            >Debabrata Bhattacharya</a
+          >
+        </p>
+      </vstack>
+      <hstack spacing="s" stretch="" align-x="center" align-y="center">
+        <h2>Reset your password</h2>
+      </hstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack>
+              <form method="POST">
+                {% csrf_token %} {{form.as_p}}
+                <button type="submit" value="login">RESET</button>
+              </form>
+              <a href="{% url 'invoicing:home' %}">Back to home</a>
+            </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <vstack spacing="s" stretch="" align-x="center" align-y="center">
+            <h3>
+              This app is made to function as a personal invoicing app for
+              freelancers.
+            </h3>
+            <h3>This app promises the following:</h3>
+            <ul>
+              <li>The ability to generate invoices</li>
+              <li>The ability to store invoice data as a set of fields</li>
+              <li>The ability to log into the application</li>
+              <li>The ability to generate PDF invoices</li>
+              <li>The ability to retrieve invoices and view them</li>
+            </ul>
+          </vstack>
+        </vstack>
+      </vstack>
+      <spacer></spacer>
+      <vstack spacing="l">
+        <vstack spacing="xs">
+          <aside class="pa-s">
+            <vstack> </vstack>
+          </aside>
+        </vstack>
+      </vstack>
+    </vstack>
+  </main>
+</body>
+{% endblock header_content %}

--- a/django_invoicing/users/tests.py
+++ b/django_invoicing/users/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/django_invoicing/users/urls.py
+++ b/django_invoicing/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+from users import views
+
+urlpatterns = [
+    path("accounts/", include("django.contrib.auth.urls")),
+]

--- a/django_invoicing/users/urls.py
+++ b/django_invoicing/users/urls.py
@@ -3,4 +3,5 @@ from users import views
 
 urlpatterns = [
     path("accounts/", include("django.contrib.auth.urls")),
+    path("accounts/register/", views.register, name="register"),
 ]

--- a/django_invoicing/users/views.py
+++ b/django_invoicing/users/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/django_invoicing/users/views.py
+++ b/django_invoicing/users/views.py
@@ -1,3 +1,21 @@
-from django.shortcuts import render
+from django.contrib.auth import login
+from django.shortcuts import Http404, redirect, render
+from django.urls import reverse
+from django_apps.utils import get_logger
+from users.forms import NewUserCreationForm
+
+lg = get_logger()
 
 # Create your views here.
+
+
+def register(request):
+    lg.debug("Rendering register page")
+    if request.method == "GET":
+        return render(request, "register.html", {"form": NewUserCreationForm})
+    elif request.method == "POST":
+        form = NewUserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect(reverse("invoicing:home"))

--- a/notes/Notes_checklist_app.md
+++ b/notes/Notes_checklist_app.md
@@ -75,3 +75,11 @@ Logs you in. Saves data in a PostgreSQL DB. Displays a dashboard. Enables settin
 ### Move away from travis CI to GitHub Actions
 
 - Change CI to GitHub Actions
+
+### Refactor tests
+
+- Refactor tests with fixtures
+
+### Test UI
+
+- Add selenium tests

--- a/notes/Notes_checklist_auth.md
+++ b/notes/Notes_checklist_auth.md
@@ -9,3 +9,59 @@
 - Add authentication urls
 - Add authentication templates
 - Refactor homepage to show user stuff only if logged in
+
+## Create an `users` app
+
+- Create a `users` app with `python.exe manage.py startapp users`
+- Disable password validators in settings. Just comment them out, leaving an empty list
+- Create a superuser with `python manage.py createsuperuser`
+- In homepage display the current user's username and set a default with `{{ user.username | default:"Guest" }}`
+- Run and refactor, write tests, run and refactor
+
+## Add authentication urls
+
+- Add the URLs provided by the Django authentication system into the app urls
+- Move the app to the top of the installed apps list
+- Run and refactor, write tests, run and refactor
+
+## Add authentication templates
+
+- Create a login page
+- Redirect to `homepage` in settings
+- Run and refactor, write tests, run and refactor
+- Add logout and login links to `homepage`
+- Redirect logout to `homepage` in settings
+- Run and refactor, write tests, run and refactor
+- Create a Change Passwords Pages
+- Add a password change link to the `homepage`
+- Run and refactor, write tests, run and refactor
+- Add email integration
+- Run and refactor, write tests, run and refactor
+- Create password reset templates
+- Run and refactor, write tests, run and refactor
+- Include a link to the password reset form on the login page
+- Change Email Templates
+- Run and refactor, write tests, run and refactor
+- Add the email field by inheriting the `UserCreationForm` into `CustomUserCreationForm`  that extends Django’s `UserCreationForm`
+- Run and refactor, write tests, run and refactor
+- Create a new view called `register`
+- Add `register` url to `urls.py`
+- Create a template called `register.html`
+- Add registration url to `login.html` template
+- Run and refactor, write tests, run and refactor
+- Add Login h2 header
+
+## Refactor homepage to show user stuff only if logged in
+
+- Refactor homepage to hide stuff unless logged in
+- Run and refactor, write tests, run and refactor
+
+## Fix register
+
+- Fix login button text on `register` page
+
+## Email reset
+
+- Test email reset
+- Create template for password reset confirmation `password_reset_confirm.html`
+- Create template for password reset complete `password_reset_complete.html`

--- a/notes/Notes_checklist_deploy.md
+++ b/notes/Notes_checklist_deploy.md
@@ -40,3 +40,7 @@
 - Set `heroku config:set DEBUG_COLLECTSTATIC=1`
 - Push code with `git push heroku setup:master`
 - Run tests, run, and refactor
+
+## Variables
+
+- Add env variables for deployment

--- a/notes/Notes_checklist_homepage.md
+++ b/notes/Notes_checklist_homepage.md
@@ -29,3 +29,5 @@
 ## Refactor links into real ones
 
 - Refactor the links into real ones
+- Turn the image cards into text cards like in nasaget message part
+- Add explanation for each link

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
-from os import remove
+from os import path, remove
+from pathlib import Path
 from shutil import copy, rmtree
+
+import dotenv
+from django_apps.utils import get_logger
+
+lg = get_logger()
+
+# Build paths inside the project like this: PROJ_DIR / 'subdir'.
+PROJ_DIR = Path(__file__).resolve().parent.parent
 
 
 def pytest_configure():
@@ -7,6 +16,11 @@ def pytest_configure():
         "django_invoicing/django_apps/templates/base.html",
         "django_invoicing/django_invoicing/templates/",
     )
+    try:
+        path_env = path.join(PROJ_DIR, "env\\test.env")
+        dotenv.read_dotenv(path_env)
+    except (EnvironmentError, FileNotFoundError):
+        print("Couldn't retrieve the environment variables")
 
 
 def pytest_unconfigure():

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,3 +9,14 @@ def create_user(db) -> User:
     USERNAME = environ["USERS_LOGIN_USERNAME"]
     PASSWORD = environ["USERS_LOGIN_PASSWORD"]
     return User.objects.create_user(username=USERNAME, password=PASSWORD)
+
+
+@pytest.fixture
+def logged_in(db, client, create_user):
+    USERNAME = environ["USERS_LOGIN_USERNAME"]
+    PASSWORD = environ["USERS_LOGIN_PASSWORD"]
+
+    # Log client in and check login
+    client.login(username=USERNAME, password=PASSWORD)
+
+    return client

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,11 @@
+from os import environ
+
+import pytest
+from django.contrib.auth.models import User
+
+
+@pytest.fixture
+def create_user(db) -> User:
+    USERNAME = environ["USERS_LOGIN_USERNAME"]
+    PASSWORD = environ["USERS_LOGIN_PASSWORD"]
+    return User.objects.create_user(username=USERNAME, password=PASSWORD)

--- a/tests/test_django_invoicing.py
+++ b/tests/test_django_invoicing.py
@@ -3,6 +3,8 @@ import pytest
 from django.urls import reverse
 from django_apps.utils import get_logger
 
+from tests.fixtures import create_user, logged_in
+
 lg = get_logger()
 
 # This is supposed to fail
@@ -14,3 +16,20 @@ def test_view_homepage(client):
     url = reverse("invoicing:home")
     response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_reach_authenticated_only_content_home(client, create_user, logged_in):
+    url = reverse("invoicing:home")
+    response = client.get(url)
+    assert (
+        "Your Dashboard" in response.content.decode()
+    ), "Cannot reach authenticated content"
+
+
+def test_dont_reach_authenticated_only_content_home(client):
+    url = reverse("invoicing:home")
+    response = client.get(url)
+    assert (
+        "Your Dashboard" not in response.content.decode()
+    ), "Authenticated content is reachable without authentication"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django_apps.utils import get_logger
 from pytest_django.asserts import assertRedirects
 
-from tests.fixtures import create_user
+from tests.fixtures import create_user, logged_in
 
 lg = get_logger()
 
@@ -62,3 +62,19 @@ def test_users_logout(client, create_user):
         status_code=302,
         msg_prefix="Failed to redirect to homepage aftre logout",
     )
+
+
+@pytest.mark.django_db
+def test_view_users_password_change_status(client, create_user, logged_in):
+    url = reverse("password_change")
+    response = client.get(url)
+    assert response.status_code == 200, "Cant reach passowrd change page"
+
+
+@pytest.mark.django_db
+def test_view_users_password_change_done_status(
+    client, create_user, logged_in
+):
+    url = reverse("password_change_done")
+    response = client.get(url)
+    assert response.status_code == 200, "Cant reach passowrd change done page"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,36 @@
+""" Tests for 'users' app """
+from os import environ
+
+import pytest
+from django.urls import reverse
+from django_apps.utils import get_logger
+from pytest_django.asserts import SimpleTestCase
+
+from tests.fixtures import create_user
+
+lg = get_logger()
+
+# This is supposed to fail
+def test_helloworld():
+    assert True == True, "Basic tests failing"
+
+
+def test_view_users_login_status(client):
+    url = "/users/accounts/login/"
+    response = client.get(url)
+    assert response.status_code == 200, "Cant reach login page"
+
+
+@pytest.mark.django_db
+def test_users_login(client, create_user):
+    USERNAME = environ["USERS_LOGIN_USERNAME"]
+    PASSWORD = environ["USERS_LOGIN_PASSWORD"]
+    response = client.login(username=USERNAME, password=PASSWORD)
+    assert response == True, "Failed to login to app"
+
+    url = reverse("invoicing:home")
+    response = client.post(url)
+
+    assert (
+        response.context["user"].is_authenticated == True
+    ), "Failed to verify authenticated status of user"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -78,3 +78,15 @@ def test_view_users_password_change_done_status(
     url = reverse("password_change_done")
     response = client.get(url)
     assert response.status_code == 200, "Cant reach passowrd change done page"
+
+
+def test_view_users_password_reset_status(client):
+    url = reverse("password_reset")
+    response = client.get(url)
+    assert response.status_code == 200, "Cant reach passowrd reset page"
+
+
+def test_view_users_password_reset_done_status(client):
+    url = reverse("password_reset_done")
+    response = client.get(url)
+    assert response.status_code == 200, "Cant reach passowrd reset done page"

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ passenv =
     SOCIAL_AUTH_GITHUB_SECRET
 
 [pytest]
+addopts = --reuse-db -vv
 minversion = 6.1
 python_paths = django_invoicing/
 DJANGO_SETTINGS_MODULE = django_apps.settings


### PR DESCRIPTION
# Setup authentication

- Setup authentication
- Show user stuff in homepage only if logged in

## Main tasks

- Create an `users` app
- Add authentication urls
- Add authentication templates
- Refactor homepage to show user stuff only if logged in

## Create an `users` app

- Create a `users` app with `python.exe manage.py startapp users`
- Disable password validators in settings. Just comment them out, leaving an empty list
- Create a superuser with `python manage.py createsuperuser`
- In homepage display the current user's username and set a default with `{{ user.username | default:"Guest" }}`
- Run and refactor, write tests, run and refactor

## Add authentication urls

- Add the URLs provided by the Django authentication system into the app urls
- Move the app to the top of the installed apps list
- Run and refactor, write tests, run and refactor

## Add authentication templates

- Create a login page
- Redirect to `homepage` in settings
- Run and refactor, write tests, run and refactor
- Add logout and login links to `homepage`
- Redirect logout to `homepage` in settings
- Run and refactor, write tests, run and refactor
- Create a Change Passwords Pages
- Add a password change link to the `homepage`
- Run and refactor, write tests, run and refactor
- Add email integration
- Run and refactor, write tests, run and refactor
- Create password reset templates
- Run and refactor, write tests, run and refactor
- Include a link to the password reset form on the login page
- Change Email Templates
- Run and refactor, write tests, run and refactor
- Add the email field by inheriting the `UserCreationForm` into `CustomUserCreationForm`  that extends Django’s `UserCreationForm`
- Run and refactor, write tests, run and refactor
- Create a new view called `register`
- Add `register` url to `urls.py`
- Create a template called `register.html`
- Add registration url to `login.html` template
- Run and refactor, write tests, run and refactor
- Add Login h2 header

## Refactor homepage to show user stuff only if logged in

- Refactor homepage to hide stuff unless logged in
- Run and refactor, write tests, run and refactor

## Fix register

- Fix login button text on `register` page

## Email reset

- Test email reset
- Create template for password reset confirmation `password_reset_confirm.html`
- Create template for password reset complete `password_reset_complete.html`

Closes #5 